### PR TITLE
Fix bugs: Safari SVG, resize, form security, accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       stroke-dasharray:490 44;
       stroke-dashoffset:534;
       animation:drawCircle 2s ease-out 0.3s forwards, spinCircle 12s linear 2.5s infinite;
-      transform-origin:100px 100px;
+      transform-origin:center; transform-box:fill-box;
     }
 
     .logo-a, .logo-li{
@@ -179,9 +179,9 @@
     }
 
     @keyframes textShimmer{
-      0%{fill:var(--brand); filter:brightness(1);}
-      50%{fill:#a0c4f0; filter:brightness(1.4);}
-      100%{fill:var(--brand); filter:brightness(1);}
+      0%{fill:#78aae6; filter:brightness(1);}
+      50%{fill:#b8d4f5; filter:brightness(1.3);}
+      100%{fill:#78aae6; filter:brightness(1);}
     }
 
     @keyframes logoGlow{
@@ -245,6 +245,15 @@
       .qr-code img{width:180px; height:180px;}
       .message-form{padding:24px 20px;}
     }
+
+    @media(prefers-reduced-motion:reduce){
+      *, *::before, *::after{
+        animation-duration:0.01ms !important;
+        animation-iteration-count:1 !important;
+        transition-duration:0.01ms !important;
+      }
+      #bg-canvas{display:none;}
+    }
   </style>
 </head>
 <body>
@@ -285,7 +294,7 @@
       <div class="qr-section">
         <h2>Scan to Save Contact</h2>
         <div class="qr-code">
-          <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=BEGIN:VCARD%0AVERSION:3.0%0AFN:Ali%20Alessa%0ATEL;TYPE=CELL:+966507254625%0AEMAIL:contact@alialessa.info%0AURL:https://alialessa.info%0AEND:VCARD" alt="QR Code - Contact Information" />
+          <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=BEGIN:VCARD%0AVERSION:3.0%0AFN:Ali%20Alessa%0ATEL;TYPE=CELL:+966507254625%0AEMAIL:contact@alialessa.info%0AURL:https://alialessa.info%0AEND:VCARD" alt="QR Code - Contact Information" loading="lazy" />
         </div>
         <p class="qr-label">Scan with your camera to add contact</p>
       </div>
@@ -320,15 +329,17 @@
           <input type="hidden" name="_subject" value="New message from alialessa.info">
           <input type="hidden" name="_captcha" value="false">
           <input type="hidden" name="_template" value="table">
+          <input type="hidden" name="_next" value="https://alialessa.info/">
+          <input type="text" name="_honey" style="display:none" tabindex="-1" autocomplete="off">
 
           <div class="form-group">
             <label for="name">Name</label>
-            <input type="text" id="name" name="name" required placeholder="Your name">
+            <input type="text" id="name" name="name" required placeholder="Your name" autocomplete="name">
           </div>
 
           <div class="form-group">
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" required placeholder="your@email.com">
+            <input type="email" id="email" name="email" required placeholder="your@email.com" autocomplete="email">
           </div>
 
           <div class="form-group">
@@ -369,12 +380,20 @@
       var count = 60;
       var connectDist = 140;
 
+      var resizeTimer;
       function resize(){
+        var oldW = canvas.width, oldH = canvas.height;
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
+        if(oldW && oldH){
+          for(var k = 0; k < particles.length; k++){
+            particles[k].x *= canvas.width / oldW;
+            particles[k].y *= canvas.height / oldH;
+          }
+        }
       }
       resize();
-      window.addEventListener('resize', resize);
+      window.addEventListener('resize', function(){ clearTimeout(resizeTimer); resizeTimer = setTimeout(resize, 100); });
 
       function Particle(){
         this.x = Math.random() * canvas.width;


### PR DESCRIPTION
1. Fix SVG transform-origin Safari bug: use transform-box:fill-box and transform-origin:center instead of pixel values
2. Fix canvas resize: particles now scale proportionally when window resizes, with debounced resize handler
3. Form security: add honeypot field (_honey) for spam prevention and _next redirect back to site after submission
4. Accessibility: add prefers-reduced-motion media query that disables all animations and hides canvas for users who prefer reduced motion
5. Fix textShimmer color jump: animation now uses #78aae6 (matching the actual SVG fill) instead of --brand (#4a7ab5)
6. Add loading="lazy" to QR code image
7. Add autocomplete attributes to form inputs

https://claude.ai/code/session_01VrJrAHRNwR2nXb9W2o3nVT